### PR TITLE
chore: update lsh to v1.5.3

### DIFF
--- a/lsh.rb
+++ b/lsh.rb
@@ -1,50 +1,31 @@
-# typed: false
-# frozen_string_literal: true
-
 class Lsh < Formula
-  desc ""
+  desc "Latitude.sh CLI tool"
   homepage "https://www.latitude.sh/"
-  version "1.4.0"
+  version "1.5.3"
+  license "MIT"
 
   on_macos do
-    on_intel do
-      url "https://github.com/latitudesh/cli/releases/download/v1.4.2/lsh_Darwin_x86_64.tar.gz"
-      sha256 "d019deb790bdb20db464c2f09453dca2d834ea77b703476afa2f9227265e1678"
-
-      def install
-        bin.install "lsh"
-      end
-    end
-    on_arm do
-      url "https://github.com/latitudesh/cli/releases/download/v1.4.2/lsh_Darwin_arm64.tar.gz"
-      sha256 "e832601135259bee7a0b22eab71df233bb4a20e7186cb630a738bf8d2680dbf5"
-
-      def install
-        bin.install "lsh"
-      end
+    if Hardware::CPU.arm?
+      url "https://github.com/latitudesh/cli/releases/download/v1.5.3/lsh_Darwin_arm64.tar.gz"
+      sha256 "f2b8081ac17d2aeb7adcccc7b00f33263f47783f45154179dbc10e5e9ae86c12"
+    else
+      url "https://github.com/latitudesh/cli/releases/download/v1.5.3/lsh_Darwin_x86_64.tar.gz"
+      sha256 "bf0c4714f058433827e9cc209e104e498dab9239ffb262506ddd3cdee8b4f4d8"
     end
   end
 
   on_linux do
-    on_intel do
-      if Hardware::CPU.is_64_bit?
-        url "https://github.com/latitudesh/cli/releases/download/v1.4.2/lsh_Linux_x86_64.tar.gz"
-        sha256 "642ad72e70ac91b070d9e97c9544637b35f8e6f8406dbae973ca0329b33ae177"
-
-        def install
-          bin.install "lsh"
-        end
-      end
+    if Hardware::CPU.intel?
+      url "https://github.com/latitudesh/cli/releases/download/v1.5.3/lsh_Linux_x86_64.tar.gz"
+      sha256 "e473dcdeba12ccba5fa6de9c52c4936a93edb6265699359594a448f0ed386bda"
     end
-    on_arm do
-      if Hardware::CPU.is_64_bit?
-        url "https://github.com/latitudesh/cli/releases/download/v1.4.2/lsh_Linux_arm64.tar.gz"
-        sha256 "754a612fb34700958196be80f351168288305cdd8f6cda9e5977d3b56259095e"
+  end
 
-        def install
-          bin.install "lsh"
-        end
-      end
-    end
+  def install
+    bin.install "lsh"
+  end
+
+  test do
+    system "#{bin}/lsh", "version"
   end
 end


### PR DESCRIPTION
Updates lsh Homebrew formula to version v1.5.3

Auto-generated by release workflow.