### PR TITLE
chore: update lsh to v1.5.4

### DIFF
--- a/lsh.rb
+++ b/lsh.rb
@@ -1,23 +1,23 @@
 class Lsh < Formula
   desc "Latitude.sh CLI tool"
   homepage "https://www.latitude.sh/"
-  version "1.5.3"
+  version "1.5.4"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/latitudesh/cli/releases/download/v1.5.3/lsh_Darwin_arm64.tar.gz"
-      sha256 "f2b8081ac17d2aeb7adcccc7b00f33263f47783f45154179dbc10e5e9ae86c12"
+      url "https://github.com/latitudesh/cli/releases/download/v1.5.4/lsh_Darwin_arm64.tar.gz"
+      sha256 "c259fd80037727101a835059cfcb2ed0d1c4866ed0ef0b966b221a8ffa03b721"
     else
-      url "https://github.com/latitudesh/cli/releases/download/v1.5.3/lsh_Darwin_x86_64.tar.gz"
-      sha256 "bf0c4714f058433827e9cc209e104e498dab9239ffb262506ddd3cdee8b4f4d8"
+      url "https://github.com/latitudesh/cli/releases/download/v1.5.4/lsh_Darwin_x86_64.tar.gz"
+      sha256 "8ead40622b57cbf916058c91b84d4ef3a614c062c05c1916b8b7cc0d22b94ee5"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/latitudesh/cli/releases/download/v1.5.3/lsh_Linux_x86_64.tar.gz"
-      sha256 "e473dcdeba12ccba5fa6de9c52c4936a93edb6265699359594a448f0ed386bda"
+      url "https://github.com/latitudesh/cli/releases/download/v1.5.4/lsh_Linux_x86_64.tar.gz"
+      sha256 "fd9bd387c3d61b88e100b95225dbfcffa865ebc228b9dc3f878fea035a71ea81"
     end
   end
 


### PR DESCRIPTION
Updates lsh Homebrew formula to version v1.5.4

Auto-generated by release workflow.