### PR TITLE
chore: update lsh to v1.5.5

### DIFF
--- a/lsh.rb
+++ b/lsh.rb
@@ -1,23 +1,23 @@
 class Lsh < Formula
   desc "Latitude.sh CLI tool"
   homepage "https://www.latitude.sh/"
-  version "1.5.4"
+  version "1.5.5"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/latitudesh/cli/releases/download/v1.5.4/lsh_Darwin_arm64.tar.gz"
-      sha256 "c259fd80037727101a835059cfcb2ed0d1c4866ed0ef0b966b221a8ffa03b721"
+      url "https://github.com/latitudesh/cli/releases/download/v1.5.5/lsh_Darwin_arm64.tar.gz"
+      sha256 "073fc8d80c758c194060ecb541d53d0890e4881e115d21129dd3160a3512637e"
     else
-      url "https://github.com/latitudesh/cli/releases/download/v1.5.4/lsh_Darwin_x86_64.tar.gz"
-      sha256 "8ead40622b57cbf916058c91b84d4ef3a614c062c05c1916b8b7cc0d22b94ee5"
+      url "https://github.com/latitudesh/cli/releases/download/v1.5.5/lsh_Darwin_x86_64.tar.gz"
+      sha256 "9d3981f9a6ba6ae46aacaa0b4a6c2293f298142fc466afd9c1404cb2da42cd9b"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/latitudesh/cli/releases/download/v1.5.4/lsh_Linux_x86_64.tar.gz"
-      sha256 "fd9bd387c3d61b88e100b95225dbfcffa865ebc228b9dc3f878fea035a71ea81"
+      url "https://github.com/latitudesh/cli/releases/download/v1.5.5/lsh_Linux_x86_64.tar.gz"
+      sha256 "b41d31c58f5f51a9d8b1a4a4c8f3cfecd542542a95823c506d895910a38b1d35"
     end
   end
 


### PR DESCRIPTION
Updates lsh Homebrew formula to version v1.5.5

Auto-generated by release workflow.